### PR TITLE
Adding new class and fixing IngestRequest class to allow retranscoding requests.

### DIFF
--- a/lib/Brightcove/API/Request/IngestRequest.php
+++ b/lib/Brightcove/API/Request/IngestRequest.php
@@ -44,7 +44,7 @@ class IngestRequest extends ObjectBase {
     $this->fieldAliases["capture_images"] = "capture-images";
   }
 
-  public static function createRequest($url, $profile) {
+  public static function createRequest($profile, $url = null) {
     $request = new self();
     if ($url !== null) {
       $request->setMaster(new IngestRequestMaster());

--- a/lib/Brightcove/API/Request/IngestRequest.php
+++ b/lib/Brightcove/API/Request/IngestRequest.php
@@ -6,7 +6,7 @@ use Brightcove\Object\ObjectBase;
 
 class IngestRequest extends ObjectBase {
   /**
-   * @var IngestRequestMaster
+   * @var IngestRequestMaster|IngestRequestRetranscode
    */
   protected $master;
 
@@ -70,17 +70,17 @@ class IngestRequest extends ObjectBase {
   }
 
   /**
-   * @return IngestRequestMaster
+   * @return IngestRequestMaster|IngestRequestRetranscode
    */
   public function getMaster() {
     return $this->master;
   }
 
   /**
-   * @param IngestRequestMaster $master
+   * @param IngestRequestMaster|IngestRequestRetranscode $master
    * @return $this
    */
-  public function setMaster(IngestRequestMaster $master = NULL) {
+  public function setMaster(ObjectBase $master = NULL) {
     $this->master = $master;
     $this->fieldChanged('master');
     return $this;

--- a/lib/Brightcove/API/Request/IngestRequest.php
+++ b/lib/Brightcove/API/Request/IngestRequest.php
@@ -46,8 +46,13 @@ class IngestRequest extends ObjectBase {
 
   public static function createRequest($url, $profile) {
     $request = new self();
-    $request->setMaster(new IngestRequestMaster());
-    $request->getMaster()->setUrl($url);
+    if ($url !== null) {
+      $request->setMaster(new IngestRequestMaster());
+      $request->getMaster()->setUrl($url);
+    } else {
+      $request->setMaster(new IngestRequestRetranscode());
+      $request->getMaster()->setUseArchivedMaster(true);
+    }
     $request->setProfile($profile);
 
     return $request;

--- a/lib/Brightcove/API/Request/IngestRequestRetranscode.php
+++ b/lib/Brightcove/API/Request/IngestRequestRetranscode.php
@@ -10,7 +10,7 @@ class IngestRequestRetranscode extends ObjectBase {
     public function applyJSON(array $json)
     {
         parent::applyJSON($json);
-        $this->applyProperty($json, 'url');
+        $this->applyProperty($json, 'use_archived_master');
     }
 
     /**

--- a/lib/Brightcove/API/Request/IngestRequestRetranscode.php
+++ b/lib/Brightcove/API/Request/IngestRequestRetranscode.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Brightcove\API\Request;
+
+use Brightcove\Object\ObjectBase;
+
+class IngestRequestRetranscode extends ObjectBase {
+    protected $use_archived_master;
+
+    public function applyJSON(array $json)
+    {
+        parent::applyJSON($json);
+        $this->applyProperty($json, 'url');
+    }
+
+    /**
+     * @return string
+     */
+    public function getUseArchivedMaster()
+    {
+        return $this->getUseArchivedMaster();
+    }
+
+    /**
+     * @param string $use_archived_master
+     * @return $this
+     */
+    public function setUseArchivedMaster($bool = true)
+    {
+        $this->use_archived_master = $bool;
+        $this->fieldChanged('use_archived_master');
+        return $this;
+    }
+}

--- a/test/Brightcove/Test/VideoCRUDTest.php
+++ b/test/Brightcove/Test/VideoCRUDTest.php
@@ -26,7 +26,7 @@ class VideoCRUDTest extends TestBase {
    * @depends testVideoObjectCreation
    */
   public function testVideoIngestion($video_id) {
-    $request = IngestRequest::createRequest('http://download.blender.org/peach/bigbuckbunny_movies/big_buck_bunny_480p_surround-fix.avi', 'high-bandwidth-devices');
+    $request = IngestRequest::createRequest('high-bandwidth-devices', 'http://download.blender.org/peach/bigbuckbunny_movies/big_buck_bunny_480p_surround-fix.avi');
     if (!empty($this->callback_addr_remote)) {
       $request->setCallbacks([$this->callback_addr_remote]);
     }


### PR DESCRIPTION
Added a new class IngestRequestRetranscode with single attribute use_archived_master mirroring Brightcove Dynamic Ingest API field, to be filled with bool (default to true).

Modified IngestRequest::createIngest() to reflect new possibility: changed param order to make $url optional, create conditional statement for selecting proper IngestRequestMaster/Retranscode field.