### PR TITLE
Add projection setting in Video Object

### DIFF
--- a/lib/Brightcove/Object/Video/Video.php
+++ b/lib/Brightcove/Object/Video/Video.php
@@ -149,6 +149,12 @@ class Video extends ObjectBase {
    * @var string
    */
   protected $updated_at;
+  /**
+   * The mapping projection for 360° videos, e.g. "equirectangular"
+   *
+   * @var string
+   */
+  protected $projection;
 
   public function applyJSON(array $json) {
     parent::applyJSON($json);
@@ -174,6 +180,7 @@ class Video extends ObjectBase {
     $this->applyProperty($json, 'tags');
     $this->applyProperty($json, 'text_tracks', NULL, TextTrack::class, TRUE);
     $this->applyProperty($json, 'updated_at');
+    $this->applyProperty($json, 'projection');
   }
 
   /**
@@ -548,5 +555,22 @@ class Video extends ObjectBase {
     $this->updated_at = $updated_at;
     $this->fieldChanged('updated_at');
     return $this;
+  }
+  
+  /**
+   * @return string
+   */
+  public function getProjection() {
+      return $this->projection;
+  }
+  
+  /**
+   * @param string $projection
+   * @return $this
+   */
+  public function setProjection($projection) {
+      $this->projection = $projection;
+      $this->fieldChanged('projection');
+      return $this;
   }
 }


### PR DESCRIPTION
Hello,

The Video Object from the PHP API seems to not be updated with the projection setting in the CMS API as explained here: https://support.brightcove.com/cms-api-video-fields-reference

I added the missing parameter I needed.

Best regards.