### PR TITLE
Feature/set videos for smart playlists

### DIFF
--- a/lib/Brightcove/API/CMS.php
+++ b/lib/Brightcove/API/CMS.php
@@ -151,7 +151,7 @@ class CMS extends API {
     // separately.
     $smart_playlists = [];
     foreach ($playlists as $key => $playlist) {
-      /* @var \Drupal\brightcove\Playlist $playlist */
+      /* @var \Brightcove\Object\Playlist $playlist */
       if ($playlist->getType() !== 'EXPLICIT') {
         $smart_playlists[$key] = $playlist->getId();
       }
@@ -162,11 +162,10 @@ class CMS extends API {
         $video_ids = getSmartPlaylistVideos("/playlists/{$smart_playlist_id}/videos");
 
         if (!empty($video_ids)) {
-          /* @var \Drupal\brightcove\Playlist $playlist */
+          /* @var \Brightcove\Object\Playlist $playlist */
           $playlist = $playlists[$playlist_key];
           $playlist->setVideoIds($video_ids);
         }
-
       }
     }
     return $playlists;

--- a/lib/Brightcove/API/CMS.php
+++ b/lib/Brightcove/API/CMS.php
@@ -144,7 +144,50 @@ class CMS extends API {
     if (strlen($query) > 0) {
       $query = '?' . substr($query, 1);
     }
-    return $this->cmsRequest('GET', "/playlists{$query}", Playlist::class, TRUE);
+
+    $playlists = $this->cmsRequest('GET', "/playlists{$query}", Playlist::class, TRUE);
+
+    // Check if there are smart playlists as we need to build their videos
+    // separately.
+    $smart_playlists = [];
+    foreach ($playlists as $key => $playlist) {
+      /* @var \Drupal\brightcove\Playlist $playlist */
+      if ($playlist->getType() !== 'EXPLICIT') {
+        $smart_playlists[$key] = $playlist->getId();
+      }
+    }
+
+    if (!empty($smart_playlists)) {
+      foreach ($smart_playlists as $playlist_key => $smart_playlist_id) {
+        $video_ids = getSmartPlaylistVideos("/playlists/{$smart_playlist_id}/videos");
+
+        if (!empty($video_ids)) {
+          /* @var \Drupal\brightcove\Playlist $playlist */
+          $playlist = $playlists[$playlist_key];
+          $playlist->setVideoIds($video_ids);
+        }
+
+      }
+    }
+    return $playlists;
+  }
+
+  /**
+   * Get smart playlist videos to add to the Playlist objects.
+   *
+   * @param string $endpoint
+   *   Endpoint to get smart playlist videos.
+   *
+   * @return array
+   *   Video ids.
+   */
+  protected function getSmartPlaylistVideos($endpoint) {
+    $video_results = $this->cmsRequest('GET', $endpoint, NULL);
+    $video_ids = [];
+    foreach ($video_results as $video) {
+      $video_ids[] = $video['id'];
+    }
+    return $video_ids;
   }
 
   /**


### PR DESCRIPTION
Currently, CMS::listPlaylists() will return an array of Playlist objects but smart playlists are treated differently than manual ones.  For smart playlists, the video property will be empty while manual playlists will have an array of video ids.  This can cause issues downstream if developers expect them to behave the same.  

The Drupal module https://cgit.drupalcode.org/brightcove/tree/?h=8.x-1.x, uses this API to save Playlist and videos into Drupal.  For our use case, we would like the ability to save videos regardless of the type of playlist.  

This is my first attempt and would love to hear feedback and concerns about this solution.